### PR TITLE
Add pointers to Spring Cloud Stream guides in the Microsite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+*~
+.#*
+*#
+*.sw*
+_site/
+.factorypath
+.gradletasknamecache
+.DS_Store
+.checkstyle
+/application.yml
+/application.properties
+asciidoctor.css
+atlassian-ide-plugin.xml
+bin/
+build/
+dump.rdb
+out
+spring-shell.log
+target/
+test-output
+logs/
+scdf-logs/
+.attach_pid*
+
+# Eclipse artifacts, including WTP generated manifests
+.classpath
+.project
+.settings/
+.springBeans
+spring-*/src/main/java/META-INF/MANIFEST.MF
+
+# IDEA artifacts and output dirs
+*.iml
+*.ipr
+*.iws
+.idea/
+rebel.xml
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ rebel.xml
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,1 +1,24 @@
+== Getting Started with Spring Cloud Stream
+This guide walks you through an overview of Spring Cloud Stream and the process of creating an event-driven
+streaming application.
 
+=== What is Spring Cloud Stream?
+A framework for building event-driven Spring Boot microservices for real-time stream processing. You can learn more about
+the framework from the link:https://spring.io/projects/spring-cloud-stream[project-site] and
+link:https://spring.io/projects/spring-cloud-stream#learn[documentation].
+
+=== Stream Processing with RabbitMQ
+In the following guide, we develop three Spring Boot applications that use Spring Cloud Stream's support for RabbitMQ and deploy
+them to Cloud Foundry, to Kubernetes, and on your local machine.
+
+link:https://dataflow.spring.io/docs/stream-developer-guides/streams/standalone-stream-rabbitmq/[Stream Processing with RabbitMQ]
+
+=== Stream Processing with Apache Kafka
+In the following guide, we develop three Spring Boot applications that use Spring Cloud Stream's support for Apache Kafka and deploy
+them to Cloud Foundry, to Kubernetes, and on your local machine.
+
+link:https://dataflow.spring.io/docs/stream-developer-guides/streams/standalone-stream-kafka/[Stream Processing with Apache Kafka]
+
+== Summary
+Congratulations! You have learned Spring Cloud Stream's high-level overview, and you were able to build and test
+Spring Cloud Stream applications that communicate with RabbitMQ or Apache Kafka.

--- a/README.adoc
+++ b/README.adoc
@@ -21,5 +21,5 @@ them to Cloud Foundry, to Kubernetes, and on your local machine.
 link:https://dataflow.spring.io/docs/stream-developer-guides/streams/standalone-stream-kafka/[Stream Processing with Apache Kafka]
 
 == Summary
-Congratulations! You have learned Spring Cloud Stream's high-level overview, and you were able to build and test
+Congratulations! You have completed Spring Cloud Stream's high-level overview, and you were able to build and test
 Spring Cloud Stream applications that communicate with RabbitMQ or Apache Kafka.

--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,9 @@ streaming application.
 
 === What is Spring Cloud Stream?
 A framework for building event-driven Spring Boot microservices for real-time stream processing. You can learn more about
-the framework from the link:https://spring.io/projects/spring-cloud-stream[project-site] and
-link:https://spring.io/projects/spring-cloud-stream#learn[documentation].
+the framework from the link:https://spring.io/projects/spring-cloud-stream[project-site],
+link:https://spring.io/projects/spring-cloud-stream#learn[documentation],
+and link:https://github.com/spring-cloud/spring-cloud-stream-samples[samples].
 
 === Stream Processing with RabbitMQ
 In the following guide, we develop three Spring Boot applications that use Spring Cloud Stream's support for RabbitMQ and deploy


### PR DESCRIPTION
The goal with this approach is to avoid duplicating content that we already maintain in the Microsite. And, of course, steer everyone towards the Microsite since that is the central source of truth for all the things SCDF and ecosystem.